### PR TITLE
Set -res in cmdline_fso.cfg

### DIFF
--- a/code/apis/PlatformProfileManagerShared.cpp
+++ b/code/apis/PlatformProfileManagerShared.cpp
@@ -20,10 +20,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <wx/dir.h>
 #include <wx/filename.h>
 #include <wx/wfstream.h>
+#include <sstream>
 #include "generated/configure_launcher.h"
 #include "apis/PlatformProfileManager.h"
 #include "controls/LightingPresets.h"
 #include "global/ProfileKeys.h"
+#include "global/BasicDefaults.h"
 
 ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	wxString modLine, flagLine, tcPath;
@@ -112,6 +114,13 @@ ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 		outStream.Write(" ", 1);
 		outStream.Write(lightingPresetFlagSet.char_str(), lightingPresetFlagSet.size());
 	}
+	// work around some problems with writing to the registry on Windows
+	int width, height;
+	cfg->Read(PRO_CFG_VIDEO_RESOLUTION_WIDTH, &width, DEFAULT_VIDEO_RESOLUTION_WIDTH);
+	cfg->Read(PRO_CFG_VIDEO_RESOLUTION_HEIGHT, &height, DEFAULT_VIDEO_RESOLUTION_HEIGHT);
+	std::stringstream res;
+        res << " -res " <<  width << "x" << height;
+	outStream.Write(res.str().c_str(), res.str().size());
 	if ( !outStream.Close() ) {
 		return ProMan::UnknownError;
 	}


### PR DESCRIPTION
This worksaround recently reported issues with users being unable to
write to the Windows registry, even when running as an administrator.
Setting -res should be foolproof, although it leaves other settings out
like audio.

Also, this could be considered a massive hack, and it's my first time digging into wxlauncher. Please let me know if there's a better way...