### PR TITLE
Always surround mods with quotes

### DIFF
--- a/code/apis/PlatformProfileManagerShared.cpp
+++ b/code/apis/PlatformProfileManagerShared.cpp
@@ -102,7 +102,11 @@ ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	}
 	if ( !modLine.IsEmpty()) {
 		outStream.Write("-mod ", 5);
+
+		// Enclose the mod parameter in quotes to escape spaces
+		outStream.Write("\"", 1);
 		outStream.Write(modLine.char_str(), modLine.size());
+		outStream.Write("\"", 1);
 	}
 	if ( !flagLine.IsEmpty() ) {
 		outStream.Write(" ", 1);

--- a/code/tabs/AdvSettingsPage.cpp
+++ b/code/tabs/AdvSettingsPage.cpp
@@ -394,7 +394,7 @@ void AdvSettingsPage::OnNeedUpdateCommandLine(wxCommandEvent &WXUNUSED(event)) {
 						 wxFileName::GetPathSeparator(),
 						 exeName.c_str(),
 						 (modline.IsEmpty() ? wxEmptyString :
-							wxString::Format(_T(" -mod %s"), modline.c_str()).c_str()),
+							wxString::Format(_T(" -mod \"%s\""), modline.c_str()).c_str()),
 						 (flagFileFlags.IsEmpty() ? wxEmptyString :
 							wxString::Format(_T(" %s"), flagFileFlags.c_str()).c_str()),
 						 (lightingPresetString.IsEmpty() ? wxEmptyString :


### PR DESCRIPTION
Reported by Talon 1024 while using the Antipodes branch. The new way of parsing commandline arguments doesn't like spaces so the -mod parameter should always be enclosed in quotes to make sure that FSO can process all mods.