### PR TITLE
Add support for new unified configuration handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.{h,cpp}]
+indent_style = tab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,8 @@ set(GLOBAL_CODE_FILES
   code/global/Utils.cpp
   code/global/version.h
   code/global/version.cpp
-  )
+  code/global/Compatibility.cpp
+  code/global/Compatibility.h)
 source_group(Global FILES ${GLOBAL_CODE_FILES})
 set(DATASTRUCTURE_CODE_FILES
   code/datastructures/FlagInfo.cpp

--- a/code/MainWindow.cpp
+++ b/code/MainWindow.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <wx/imaglist.h>
 #include <wx/html/htmlwin.h>
 #include "global/ids.h"
+#include "global/Compatibility.h"
 #include "global/ProfileKeys.h"
 #include "generated/configure_launcher.h"
 #include "MainWindow.h"
@@ -188,7 +189,14 @@ void MainWindow::OnStart(wxButton* button, bool startFred) {
 		return;
 	}
 
-	if ( ProMan::NoError != ProMan::GetProfileManager()->PushCurrentProfile() ) {
+	if ( ProMan::NoError != p->PushCurrentProfile() ) {
+		button->SetLabel(defaultButtonValue);
+		button->Enable();
+		return;
+	}
+
+	if (!Compatibility::SynchronizeOldPilots(p)) {
+		wxLogError(_T("Failed to synchronize old pilot files!"));
 		button->SetLabel(defaultButtonValue);
 		button->Enable();
 		return;

--- a/code/MainWindow.cpp
+++ b/code/MainWindow.cpp
@@ -189,6 +189,13 @@ void MainWindow::OnStart(wxButton* button, bool startFred) {
 		return;
 	}
 
+	if (!Compatibility::MigrateOldConfig()) {
+		wxLogError(_T("Failed to migrate old config!!"));
+		button->SetLabel(defaultButtonValue);
+		button->Enable();
+		return;
+	}
+
 	if ( ProMan::NoError != p->PushCurrentProfile() ) {
 		button->SetLabel(defaultButtonValue);
 		button->Enable();

--- a/code/apis/FileProfileManager.cpp
+++ b/code/apis/FileProfileManager.cpp
@@ -364,6 +364,10 @@ ProMan::RegistryCodes FilePullProfile(wxFileConfig *cfg) {
 		inFileName.SetFullName(FSO_CONFIG_FILENAME);
 	}
 
+	if (!inFileName.FileExists()) {
+		return ProMan::InputFileDoesNotExist;
+	}
+
 	wxFFileInputStream inConfigStream(inFileName.GetFullPath(), _T("rb"));
 	wxFileConfig inConfig(inConfigStream, wxMBConvUTF8());
 

--- a/code/apis/FileProfileManager.cpp
+++ b/code/apis/FileProfileManager.cpp
@@ -31,10 +31,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <SDL_filesystem.h>
 
-namespace
-{
-	const int BUILD_CAP_SDL = 1 << 3;
-}
 
 // NOTE: this function is also used by PushCmdlineFSO() in PlatformProfileManagerShared.cpp
 wxFileName GetPlatformDefaultConfigFilePathOld() {
@@ -72,11 +68,11 @@ wxFileName GetPlatformDefaultConfigFilePathNew() {
 
 wxFileName GetPlatformDefaultConfigFilePath(const wxString& tcPath) {
 	wxFileName path;
-	if (FlagListManager::GetFlagListManager()->GetBuildCaps() & BUILD_CAP_SDL) {
+	if (FlagListManager::GetFlagListManager()->GetBuildCaps() & FlagListManager::BUILD_CAPS_SDL) {
 		path = GetPlatformDefaultConfigFilePathNew();
 	}
 	else {
-#if IS_LINUX // write to folder in home dir
+#if IS_LINUX || IS_APPLE // write to folder in home dir
 		path = GetPlatformDefaultConfigFilePathOld().GetFullPath().c_str();
 #else
 		path.AssignDir(tcPath);

--- a/code/apis/FileProfileManager.cpp
+++ b/code/apis/FileProfileManager.cpp
@@ -28,8 +28,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "global/ProfileKeys.h"
 #include "global/RegistryKeys.h"
 
-// NOTE: this function is also used by PushCmdlineFSO() in PlatformProfileManagerShared.cpp
+#include <SDL_filesystem.h>
+
 wxFileName GetPlatformDefaultConfigFilePath() {
+	// The sdl parameters are defined in the FSO code in the file code/osapi.cpp
+	char* prefPath = SDL_GetPrefPath("HardLightProductions", "FreeSpaceOpen");
+
+	wxString wxPrefPath = wxString::FromUTF8(prefPath);
+
+	SDL_free(prefPath);
+
+	wxFileName path;
+	path.AssignDir(wxPrefPath);
+
+	return path;
+}
+
+// NOTE: this function is also used by PushCmdlineFSO() in PlatformProfileManagerShared.cpp
+wxFileName GetPlatformDefaultConfigFilePathLegacy() {
 	wxFileName path;
 #if IS_WIN32
 	path.AssignDir(wxStandardPaths::Get().GetUserConfigDir());

--- a/code/apis/FlagListManager.h
+++ b/code/apis/FlagListManager.h
@@ -49,6 +49,13 @@ public:
 		FLAG_FILE_PROCESSING_ERROR
 	};
 
+	enum CapabilityFlags {
+		BUILD_CAPS_OPENAL = 1 << 0,
+		BUILD_CAPS_NO_D3D = 1 << 1,
+		BUILD_CAPS_NEW_SND = 1 << 2,
+		BUILD_CAPS_SDL = 1 << 3,
+	};
+
 	void OnBinaryChanged(wxCommandEvent &event);
 	
 	static void RegisterFlagFileProcessingStatusChanged(wxEvtHandler *handler);

--- a/code/apis/PlatformProfileManagerShared.cpp
+++ b/code/apis/PlatformProfileManagerShared.cpp
@@ -38,7 +38,7 @@ ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	}
 
 	extern wxFileName GetPlatformDefaultConfigFilePath(const wxString&);
-	wxString cmdLineString = GetPlatformDefaultConfigFilePath(tcPath).GetFullName();
+	wxString cmdLineString = GetPlatformDefaultConfigFilePath(tcPath).GetFullPath();
 
 	cmdLineString += _T("data");
 	

--- a/code/apis/PlatformProfileManagerShared.cpp
+++ b/code/apis/PlatformProfileManagerShared.cpp
@@ -24,12 +24,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "apis/PlatformProfileManager.h"
 #include "controls/LightingPresets.h"
 #include "global/ProfileKeys.h"
-#include "apis/FlagListManager.h"
-
-namespace
-{
-	const int BUILD_CAP_SDL = 1 << 3;
-}
 
 ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	wxString modLine, flagLine, tcPath;
@@ -43,21 +37,8 @@ ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 		lightingPresetFlagSet = LightingPresets::PresetNameToPresetFlagSet(presetName);
 	}
 
-	wxString cmdLineString;
-	if (FlagListManager::GetFlagListManager()->GetBuildCaps() & BUILD_CAP_SDL) {
-		// SDL builds now use the user directory on all platforms
-		extern wxFileName GetPlatformDefaultConfigFilePath();
-		cmdLineString += GetPlatformDefaultConfigFilePath().GetFullPath().c_str();
-	}
-	else {
-#if IS_LINUX // write to folder in home dir
-		extern wxFileName GetPlatformDefaultConfigFilePathLegacy();
-		cmdLineString += GetPlatformDefaultConfigFilePathLegacy().GetFullPath().c_str();
-#else
-		cmdLineString += tcPath.c_str();
-		cmdLineString += wxFileName::GetPathSeparator();
-#endif
-	}
+	extern wxFileName GetPlatformDefaultConfigFilePath(const wxString&);
+	wxString cmdLineString = GetPlatformDefaultConfigFilePath(tcPath).GetFullName();
 
 	cmdLineString += _T("data");
 	

--- a/code/apis/PlatformProfileManagerShared.cpp
+++ b/code/apis/PlatformProfileManagerShared.cpp
@@ -24,6 +24,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "apis/PlatformProfileManager.h"
 #include "controls/LightingPresets.h"
 #include "global/ProfileKeys.h"
+#include "apis/FlagListManager.h"
+
+namespace
+{
+	const int BUILD_CAP_SDL = 1 << 3;
+}
 
 ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	wxString modLine, flagLine, tcPath;
@@ -38,13 +44,21 @@ ProMan::RegistryCodes PushCmdlineFSO(wxFileConfig *cfg) {
 	}
 
 	wxString cmdLineString;
+	if (FlagListManager::GetFlagListManager()->GetBuildCaps() & BUILD_CAP_SDL) {
+		// SDL builds now use the user directory on all platforms
+		extern wxFileName GetPlatformDefaultConfigFilePath();
+		cmdLineString += GetPlatformDefaultConfigFilePath().GetFullPath().c_str();
+	}
+	else {
 #if IS_LINUX // write to folder in home dir
-	extern wxFileName GetPlatformDefaultConfigFilePath();
-	cmdLineString += GetPlatformDefaultConfigFilePath().GetFullPath().c_str();
+		extern wxFileName GetPlatformDefaultConfigFilePathLegacy();
+		cmdLineString += GetPlatformDefaultConfigFilePathLegacy().GetFullPath().c_str();
 #else
-	cmdLineString += tcPath.c_str();
-	cmdLineString += wxFileName::GetPathSeparator();
+		cmdLineString += tcPath.c_str();
+		cmdLineString += wxFileName::GetPathSeparator();
 #endif
+	}
+
 	cmdLineString += _T("data");
 	
 #if IS_LINUX // try to rename file in root folder if exists

--- a/code/apis/RegistryProfileManager.cpp
+++ b/code/apis/RegistryProfileManager.cpp
@@ -181,6 +181,11 @@ LPFN_ISWOW64PROCESS WinAPI::fnIsWOW64Process = NULL;
 
 HKEY GetRegistryKeyname(wxString& out_keyname)
 {
+	if (!WinAPI::IsInited())
+	{
+		WinAPI::Init();
+	}
+
 	// Every compiler from Visual Studio 2008 onward should have support for UAC
 #if _MSC_VER > 1400
 	if (WinAPI::userSIDValid)
@@ -217,11 +222,6 @@ profile to/from the registry. */
 
 ProMan::RegistryCodes RegistryPushProfile(wxFileConfig *cfg) {
 #if PLATFORM_USES_REGISTRY == 1
-	if (!WinAPI::IsInited())
-	{
-		WinAPI::Init();
-	}
-
 	wxString keyName;
 	HKEY useKey = GetRegistryKeyname(keyName);
 
@@ -650,11 +650,6 @@ ProMan::RegistryCodes RegistryPushProfile(wxFileConfig *cfg) {
 
 ProMan::RegistryCodes RegistryPullProfile(wxFileConfig *cfg) {
 #if PLATFORM_USES_REGISTRY == 1
-	if (!WinAPI::IsInited())
-	{
-		WinAPI::Init();
-	}
-
 	wxString keyName;
 	HKEY useKey = GetRegistryKeyname(keyName);
 

--- a/code/global/Compatibility.cpp
+++ b/code/global/Compatibility.cpp
@@ -1,0 +1,87 @@
+#include <wx/dir.h>
+#include <wx/filefn.h>
+
+#include "apis/FlagListManager.h"
+#include "global/Compatibility.h"
+#include "global/ProfileKeys.h"
+
+extern wxFileName GetPlatformDefaultConfigFilePathNew();
+extern wxFileName GetPlatformDefaultConfigFilePathOld();
+
+namespace Compatibility
+{
+	bool SynchronizeOldPilots(ProMan* profileManager)
+	{
+		if (!(FlagListManager::GetFlagListManager()->GetBuildCaps() & FlagListManager::BUILD_CAPS_SDL))
+		{
+			// Nothing to do, we have an old build
+			return true;
+		}
+
+		wxFileName oldConfigFolder;
+#if IS_WIN32
+		wxString rootPath;
+		if (!profileManager->ProfileRead(PRO_CFG_TC_ROOT_FOLDER, &rootPath))
+		{
+			wxLogWarning(_T("No TC root folder in configuration!"));
+			return false;
+		}
+
+		oldConfigFolder.AssignDir(rootPath, wxPATH_NATIVE);
+#else
+		oldConfigFolder.Assign(GetPlatformDefaultConfigFilePathOld());
+#endif
+
+		oldConfigFolder.AppendDir(_T("data"));
+		oldConfigFolder.AppendDir(_T("players"));
+
+		wxFileName newConfigFolder(GetPlatformDefaultConfigFilePathNew());
+		newConfigFolder.AppendDir(_T("data"));
+		newConfigFolder.AppendDir(_T("players"));
+
+		if (!oldConfigFolder.DirExists())
+		{
+			// No old config folder so there are no pilot files to copy
+			return true;
+		}
+
+		// Heuristic to determine if the files were copied before
+		if (newConfigFolder.DirExists())
+		{
+			// new players directory already exists so it was already used before
+			// Don't try to copy in this case
+			return true;
+		}
+
+		if (!newConfigFolder.Mkdir(0777, wxPATH_MKDIR_FULL))
+		{
+			wxLogError(_T("Failed to create directory '%s'"), newConfigFolder.GetFullPath().c_str());
+			return false;
+		}
+
+		// If we are here we need to copy the old pilot files
+		wxDir oldDir(oldConfigFolder.GetFullPath());
+
+		wxString pilotFile;
+		bool cont = oldDir.GetFirst(&pilotFile, wxEmptyString, wxDIR_FILES);
+
+		while (cont)
+		{
+			wxFileName pilotFileName;
+			pilotFileName.Assign(oldConfigFolder.GetFullPath(), pilotFile);
+
+			wxFileName newPilotFile;
+			newPilotFile.Assign(newConfigFolder.GetFullPath(), pilotFile);
+
+			wxLogStatus(_T("Copying '%s' to '%s'"), pilotFileName.GetFullPath().c_str(), newPilotFile.GetFullPath().c_str());
+			if (!wxCopyFile(pilotFileName.GetFullPath(), newPilotFile.GetFullPath()))
+			{
+				wxLogError(_T("Failed to copy pilot file '%s'!"), pilotFileName.GetFullPath().c_str());
+			}
+
+			cont = oldDir.GetNext(&pilotFile);
+		}
+
+		return true;
+	}
+}

--- a/code/global/Compatibility.cpp
+++ b/code/global/Compatibility.cpp
@@ -1,6 +1,7 @@
 #include <wx/dir.h>
 #include <wx/filefn.h>
 
+#include "generated/configure_launcher.h"
 #include "apis/FlagListManager.h"
 #include "global/Compatibility.h"
 #include "global/ProfileKeys.h"

--- a/code/global/Compatibility.cpp
+++ b/code/global/Compatibility.cpp
@@ -1,10 +1,84 @@
 #include <wx/dir.h>
 #include <wx/filefn.h>
+#include <wx/sstream.h>
+#include <wx/wfstream.h>
 
 #include "generated/configure_launcher.h"
 #include "apis/FlagListManager.h"
 #include "global/Compatibility.h"
 #include "global/ProfileKeys.h"
+
+#if IS_WIN32
+#include "RegistryKeys.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+extern HKEY GetRegistryKeyname(wxString& keyNameOut);
+
+bool enumRegistryValue(HKEY parent, DWORD index, wxString& valueNameOut, wxString& valueOut) {
+	valueNameOut.Clear();
+	valueOut.Clear();
+
+	WCHAR valueNameBuffer[512];
+	DWORD valueNameBufferSize = static_cast<DWORD>(sizeof(valueNameBuffer));
+
+	BYTE valueBuffer[512];
+	DWORD valueBufferSize = static_cast<DWORD>(sizeof(valueBuffer));
+
+	DWORD type;
+
+	LONG ret = RegEnumValueW(parent, index, valueNameBuffer, &valueNameBufferSize, NULL, &type, valueBuffer, &valueBufferSize);
+
+	if (ret != ERROR_SUCCESS) {
+		return false;
+	}
+
+	valueNameOut = wxString(valueNameBuffer, valueNameBufferSize);
+
+	switch (type) {
+	case REG_BINARY:
+		valueOut = wxString::From8BitData(reinterpret_cast<char*>(valueBuffer), valueBufferSize);
+		break;
+	case REG_DWORD:
+	{
+		uint32_t val = *reinterpret_cast<uint32_t*>(valueBuffer); // I feel dirty...
+		valueOut << val;
+		break;
+	}
+	case REG_QWORD:
+	{
+		uint64_t val = *reinterpret_cast<uint64_t*>(valueBuffer); // I feel dirty...
+		valueOut << val;
+		break;
+	}
+	case REG_SZ:
+		valueOut = wxString(reinterpret_cast<wchar_t*>(valueBuffer), (valueBufferSize / sizeof(WCHAR)) - 1);
+		break;
+
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+void copyValuesIntoConfig(HKEY key, wxFileConfig& config, const wxString& sectionName) {
+	config.SetPath(sectionName);
+
+	for (DWORD i = 0; ; ++i) {
+		wxString name;
+		wxString value;
+		if (!enumRegistryValue(key, i, name, value))
+		{
+			break;
+		}
+		config.Write(name, value);
+	}
+}
+#endif
+
+#define FSO_CONFIG_FILENAME _T("fs2_open.ini")
 
 extern wxFileName GetPlatformDefaultConfigFilePathNew();
 extern wxFileName GetPlatformDefaultConfigFilePathOld();
@@ -19,7 +93,7 @@ namespace Compatibility
 			return true;
 		}
 
-		wxLogVerbose(_T("Synchronizing old pilot files..."));
+		wxLogStatus(_T("Synchronizing old pilot files..."));
 		wxFileName oldConfigFolder;
 #if IS_WIN32
 		wxString rootPath;
@@ -44,7 +118,7 @@ namespace Compatibility
 		if (!oldConfigFolder.DirExists())
 		{
 			// No old config folder so there are no pilot files to copy
-			wxLogVerbose(_T("  Old pilot directory does not exist, nothing to be done."));
+			wxLogStatus(_T("  Old pilot directory does not exist, nothing to be done."));
 			return true;
 		}
 
@@ -53,7 +127,7 @@ namespace Compatibility
 		{
 			// new players directory already exists so it was already used before
 			// Don't try to copy in this case
-			wxLogVerbose(_T("  New pilot directory already exists, was probably copied before."));
+			wxLogStatus(_T("  New pilot directory already exists, was probably copied before."));
 			return true;
 		}
 
@@ -78,7 +152,7 @@ namespace Compatibility
 			wxFileName newPilotFile;
 			newPilotFile.Assign(newConfigFolder.GetFullPath(), pilotFile);
 
-			wxLogVerbose(_T("  Copying '%s' to '%s'"), pilotFileName.GetFullPath().c_str(), newPilotFile.GetFullPath().c_str());
+			wxLogStatus(_T("  Copying '%s' to '%s'"), pilotFileName.GetFullPath().c_str(), newPilotFile.GetFullPath().c_str());
 			if (!wxCopyFile(pilotFileName.GetFullPath(), newPilotFile.GetFullPath()))
 			{
 				wxLogError(_T("Failed to copy pilot file '%s'!"), pilotFileName.GetFullPath().c_str());
@@ -87,7 +161,89 @@ namespace Compatibility
 			cont = oldDir.GetNext(&pilotFile);
 		}
 
-		wxLogVerbose(_T("  Done copying pilot files."));
+		wxLogStatus(_T("  Done copying pilot files."));
+		return true;
+	}
+
+	bool MigrateOldConfig()
+	{
+		if (!(FlagListManager::GetFlagListManager()->GetBuildCaps() & FlagListManager::BUILD_CAPS_SDL))
+		{
+			// Nothing to do, we have an old build
+			return true;
+		}
+
+		wxFileName newName = GetPlatformDefaultConfigFilePathNew();
+		newName.SetFullName(FSO_CONFIG_FILENAME);
+
+		if (wxFile::Exists(newName.GetFullPath())) {
+			// New file already exists, nothing to do here
+			return true;
+		}
+
+		wxLogStatus(_T("Migrating old configuration..."));
+#if IS_WIN32
+		// On Windows this is implemented by iterating through the registry and copying the values to the config file
+		wxString keyName;
+		HKEY useKey = GetRegistryKeyname(keyName);
+
+		LONG ret = ERROR_SUCCESS;
+		HKEY regHandle = 0;
+		ret = RegOpenKeyExW(useKey,
+			keyName.wc_str(),
+			0,
+			KEY_READ,
+			&regHandle
+			);
+		if (ret != ERROR_SUCCESS) {
+			// Key does not exists or some other error, assume it doesn't exist
+			return true; // No old config, nothing to do here
+		}
+
+		wxStringInputStream configBlankInputStream(_T(""));
+
+		wxFileConfig outConfig(configBlankInputStream, wxMBConvUTF8());
+
+		copyValuesIntoConfig(regHandle, outConfig, REG_KEY_DEFAULT_FOLDER_CFG);
+
+		for (DWORD i = 0;; ++i) {
+			WCHAR subkey[255];
+			DWORD subkeyLen = 255;
+
+			LONG res = RegEnumKeyExW(regHandle, i, subkey, &subkeyLen, NULL, NULL, NULL, NULL);
+			if (res != ERROR_SUCCESS)
+				break;
+
+			HKEY handle;
+			res = RegOpenKeyExW(regHandle, subkey, 0, KEY_READ, &handle);
+			if (res != ERROR_SUCCESS) {
+				continue;
+			}
+			wxString sectionName(subkey, subkeyLen);
+
+			sectionName = wxString::FromAscii("/") + sectionName;
+
+			copyValuesIntoConfig(handle, outConfig, sectionName);
+			RegCloseKey(handle);
+		}
+
+		RegCloseKey(regHandle);
+
+		wxLogStatus(_T("Writing fs2_open.ini to %s"), newName.GetFullPath().c_str());
+		wxFFileOutputStream outFileStream(newName.GetFullPath());
+
+		outConfig.Save(outFileStream, wxMBConvUTF8());
+#else
+		wxFileName oldName = GetPlatformDefaultConfigFilePathOld();
+		oldName.SetFullName(FSO_CONFIG_FILENAME);
+
+		if (!wxCopyFile(oldName.GetFullPath(), newName.GetFullPath())) {
+			wxLogError(_T("Failed to copy old configuration file to new location!"));
+			return false;
+		}
+#endif
+
+		wxLogStatus(_T("Migration finished."));
 		return true;
 	}
 }

--- a/code/global/Compatibility.cpp
+++ b/code/global/Compatibility.cpp
@@ -19,6 +19,7 @@ namespace Compatibility
 			return true;
 		}
 
+		wxLogVerbose(_T("Synchronizing old pilot files..."));
 		wxFileName oldConfigFolder;
 #if IS_WIN32
 		wxString rootPath;
@@ -43,6 +44,7 @@ namespace Compatibility
 		if (!oldConfigFolder.DirExists())
 		{
 			// No old config folder so there are no pilot files to copy
+			wxLogVerbose(_T("  Old pilot directory does not exist, nothing to be done."));
 			return true;
 		}
 
@@ -51,6 +53,7 @@ namespace Compatibility
 		{
 			// new players directory already exists so it was already used before
 			// Don't try to copy in this case
+			wxLogVerbose(_T("  New pilot directory already exists, was probably copied before."));
 			return true;
 		}
 
@@ -66,6 +69,7 @@ namespace Compatibility
 		wxString pilotFile;
 		bool cont = oldDir.GetFirst(&pilotFile, wxEmptyString, wxDIR_FILES);
 
+		wxLogStatus(_T("Copying pilot files from '%s' to '%s'."), oldConfigFolder.GetFullPath().c_str(), newConfigFolder.GetFullPath().c_str());
 		while (cont)
 		{
 			wxFileName pilotFileName;
@@ -74,7 +78,7 @@ namespace Compatibility
 			wxFileName newPilotFile;
 			newPilotFile.Assign(newConfigFolder.GetFullPath(), pilotFile);
 
-			wxLogStatus(_T("Copying '%s' to '%s'"), pilotFileName.GetFullPath().c_str(), newPilotFile.GetFullPath().c_str());
+			wxLogVerbose(_T("  Copying '%s' to '%s'"), pilotFileName.GetFullPath().c_str(), newPilotFile.GetFullPath().c_str());
 			if (!wxCopyFile(pilotFileName.GetFullPath(), newPilotFile.GetFullPath()))
 			{
 				wxLogError(_T("Failed to copy pilot file '%s'!"), pilotFileName.GetFullPath().c_str());
@@ -83,6 +87,7 @@ namespace Compatibility
 			cont = oldDir.GetNext(&pilotFile);
 		}
 
+		wxLogVerbose(_T("  Done copying pilot files."));
 		return true;
 	}
 }

--- a/code/global/Compatibility.h
+++ b/code/global/Compatibility.h
@@ -10,6 +10,8 @@
 namespace Compatibility
 {
 	bool SynchronizeOldPilots(ProMan* profileManager);
+
+	bool MigrateOldConfig();
 }
 
 #endif //WXLAUNCHER_COMPATIBILITY_H

--- a/code/global/Compatibility.h
+++ b/code/global/Compatibility.h
@@ -1,0 +1,15 @@
+//
+// Created by maassms on 20.08.15.
+//
+
+#ifndef WXLAUNCHER_COMPATIBILITY_H
+#define WXLAUNCHER_COMPATIBILITY_H
+
+#include "apis/ProfileManager.h"
+
+namespace Compatibility
+{
+	bool SynchronizeOldPilots(ProMan* profileManager);
+}
+
+#endif //WXLAUNCHER_COMPATIBILITY_H


### PR DESCRIPTION
The current antipodes branch has a new configuration system that now uses ini files on all platforms. It also uses a new user specific directory for writing all files at runtime instead of writing them to the current directory. This directory us determined by `SDL_GetPrefPath`.

These changes add support for that new behavior. This includes migrating old data to the new location by copying pilot files and old configuration data.