### PR TITLE
Support python 2 and 3 without needing to install extra libraries.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,7 +37,7 @@ Xcode, KDevelop, and of course autotools.
       * CMake 2.8
       * wxWidgets 2.8.10+ or 3.0.2
       * Python 2.7 or Python 3.4+
-      * markdown and six in Python
+      * markdown for Python
   * Windows
       * Windows SDK or Platform SDK
       * Nullsoft Scriptable Install System (NSIS)

--- a/scripts/helpparsers.py
+++ b/scripts/helpparsers.py
@@ -6,17 +6,20 @@ import traceback
 import sys
 import shutil
 
-from six.moves import html_parser
+try:
+  from html.parser import HTMLParser
+except ImportError:
+  from HTMLParser import HTMLParser
 
 from dataclasses import Tag
 from utilfunctions import update_attribute, change_filename
 
 
-class OutputParser(html_parser.HTMLParser):
+class OutputParser(HTMLParser):
   """The class is designed to be used as a base class.  It will output the same html structure as the input file into a file like object (only needs write)."""
       
   def __init__(self, file, *args, **kwargs):
-    html_parser.HTMLParser.__init__(self, *args, **kwargs)
+    HTMLParser.__init__(self, *args, **kwargs)
     
     if hasattr(file, 'write'):
       self.outputfile = file


### PR DESCRIPTION
Making this code polymorphic without needing a transition library (like future or six) is fairly trivial, since it depends entirely on one import.

I just didn't feel like trading one dependency (future) for another (six) was particularly worthwhile when neither is necessary.