### PR TITLE
Add handling of new executable names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.{h,cpp}]
+indent_style = tab

--- a/code/datastructures/FSOExecutable.h
+++ b/code/datastructures/FSOExecutable.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 class FSOExecutable: public wxClientData {
 public:
+	enum Configuration {
+		CONFIG_RELEASE,
+		CONFIG_DEBUG,
+		CONFIG_FASTDEBUG
+	};
+
 	virtual ~FSOExecutable();
 	bool SupportsDirect3D();
 	bool SupportsOpenAL();
@@ -45,7 +51,8 @@ protected:
 	int revision;
 	bool inferno;
 	int sse;
-	bool debug;
+	bool _64bit;
+	Configuration configuration;
 	int build;
 	bool antipodes;
 	int antNumber; //!< antipodes number (such as 8)


### PR DESCRIPTION
Now FastDebug and x64 builds are correctly identified.