### PR TITLE
Fix first run on Linux

### DIFF
--- a/code/global/Compatibility.cpp
+++ b/code/global/Compatibility.cpp
@@ -237,6 +237,11 @@ namespace Compatibility
 		wxFileName oldName = GetPlatformDefaultConfigFilePathOld();
 		oldName.SetFullName(FSO_CONFIG_FILENAME);
 
+		if (!wxFile::Exists(oldName.GetFullPath())) {
+			// Old file does not exist, probably first run.
+			return true;
+		}
+
 		if (!wxCopyFile(oldName.GetFullPath(), newName.GetFullPath())) {
 			wxLogError(_T("Failed to copy old configuration file to new location!"));
 			return false;


### PR DESCRIPTION
wxLauncher failed to start the game because MigrateOldConfig failed.
When no new config was present, it assumed that the old config must be
copied over to the new location. On the first run, there was no old
config, so MigrateOldConfig failed and returned false, meaning the game
was not started.

First check for the existance of the old config file and only try to
copy it if exists.