### PR TITLE
Make the binary finder explicitly case insensitive

### DIFF
--- a/code/datastructures/FSOExecutable.h
+++ b/code/datastructures/FSOExecutable.h
@@ -41,8 +41,10 @@ public:
 	static bool IsRootFolderValid(const wxFileName& path, bool quiet = false);
 	static bool HasFSOExecutables(const wxFileName& path);
 
-	static wxArrayString GetBinariesFromRootFolder(const wxFileName &path, bool quiet = false);
-	static wxArrayString GetFredBinariesFromRootFolder(const wxFileName &path, bool quiet = false);
+	static wxArrayString GetBinariesFromRootFolder(
+		const wxFileName &path, bool quiet = false);
+	static wxArrayString GetFredBinariesFromRootFolder(
+		const wxFileName &path, bool quiet = false);
 	static FSOExecutable GetBinaryVersion(wxString binaryname);
 	static bool SmellsLikeGitCommitHash(const wxString& str);
 	wxString GetVersionString() const;
@@ -65,7 +67,11 @@ protected:
 	wxByte buildCaps;
 private:
 	FSOExecutable();
-	static wxArrayString GetBinariesFromRootFolder(const wxFileName &path, const wxString &globPattern, bool quiet);
+	static wxArrayString GetBinariesFromRootFolder(
+		const wxFileName &path,
+		const wxString &startPattern,
+		const wxString &endPattern,
+		bool quiet);
 };
 
 inline bool FSOExecutable::ExecutableNameEqualTo(const wxString& str) const {


### PR DESCRIPTION
It seems that perhaps the wxDir::GetFirst and GetNext are not
contractually case insensitive (at very least is not mentioned in the
documentation) even if the windows implementation is and 3.1.0 wxMac is.

See also the precipitating discussion: http://www.hard-light.net/forums/index.php?topic=89162.msg1830787#msg1830787