### PR TITLE
Have CMake look for the system version of wxWidgets by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(DEFINED WXVER AND NOT WXVER MATCHES "PLATFORM")
   endif()
 else()
   message("-- Searching for wxWidgets")
-  find_package(wxWidgets 2.8.10
+  find_package(wxWidgets
     COMPONENTS base core net xml html adv qa richtext)
 endif()
 if(NOT wxWidgets_FOUND)


### PR DESCRIPTION
When building the project locally it's useful to try and use the local version of wxWidgets, rather than a specific version. Specifying a specific version is still possible with the WXVER variable. 
