### PR TITLE
Fix using wxLauncher with wxwidgets 3.2

### DIFF
--- a/code/apis/ProfileManager.cpp
+++ b/code/apis/ProfileManager.cpp
@@ -136,7 +136,7 @@ bool ProMan::Initialize(Flags flags) {
 	wxArrayString foundProfiles;
 	wxDir::GetAllFiles(GetProfileStorageFolder(), &foundProfiles, wxT_2("pro?????.ini"));
 
-	wxLogInfo(wxT_2(" Found %d profile(s)."), foundProfiles.Count());
+	wxLogInfo(wxT_2(" Found %u profile(s)."), static_cast<unsigned>(foundProfiles.Count()));
 	for( size_t i = 0; i < foundProfiles.Count(); i++) {
 		wxLogDebug(wxT_2("  Opening %s"), foundProfiles[i].c_str());
 		wxFFileInputStream instream(foundProfiles[i]);
@@ -1430,8 +1430,8 @@ void ProMan::TestConfigFunctions(wxConfigBase& src) {
 	wxLogDebug(_T("contents of dest config after clearing:"));
 	LogConfigContents(*dest);
 	
-	wxLogDebug(_T("after clearing, dest has %d entries and %d groups"),
-		dest->GetNumberOfEntries(true), dest->GetNumberOfGroups(true));
+	wxLogDebug(_T("after clearing, dest has %u entries and %u groups"),
+		static_cast<unsigned>(dest->GetNumberOfEntries(true)), static_cast<unsigned>(dest->GetNumberOfGroups(true)));
 	
 	wxLogDebug(_T("recopying src to dest"));
 	

--- a/code/controls/ModList.cpp
+++ b/code/controls/ModList.cpp
@@ -50,7 +50,7 @@ const wxString NO_MOD(_("(No mod)"));
 // to keep the presets box from overlapping with flag list
 const size_t MAX_PRESET_NAME_LENGTH = 32;
 
-class ModInfoDialog: wxDialog {
+class ModInfoDialog: public wxDialog {
 public:
 	ModInfoDialog(ModItem* item, wxWindow* parent);
 	void OnLinkClicked(wxHtmlLinkEvent &event);

--- a/code/datastructures/FSOExecutable.cpp
+++ b/code/datastructures/FSOExecutable.cpp
@@ -192,8 +192,8 @@ wxArrayString FSOExecutable::GetBinariesFromRootFolder(
 	
 	if (!quiet) {
 		wxString execType = startPattern.Lower().Find(_T("fred")) == wxNOT_FOUND ? _T("FS2") : _T("FRED2");
-		wxLogInfo(_T(" Found %d %s Open executables in '%s'"),
-			files.GetCount(), execType.c_str(), path.GetPath().c_str());
+		wxLogInfo(_T(" Found %u %s Open executables in '%s'"),
+			static_cast<unsigned>(files.GetCount()), execType.c_str(), path.GetPath().c_str());
 		
 		for (size_t i = 0, n = files.GetCount(); i < n; ++i) {
 			wxLogDebug(_T("Found executable: %s"), files.Item(i).c_str());


### PR DESCRIPTION
I was trying to compile wxLauncher with wxwidgets 3.2 (wxgtk3 to be specific). I was hitting this compilation error: 

```
In file included from /usr/include/wx-3.2/wx/wx.h:24:
/usr/include/wx-3.2/wx/event.h: In instantiation of ‘constexpr auto wxPrivate::DoCast(void (C::*)(E&)) [with E = wxHtmlLinkEvent; C = ModInfoDialog]’:
/home/magejohn/Source/wxLauncher/code/controls/ModList.cpp:1400:50:   required from here
/usr/include/wx-3.2/wx/event.h:157:12: error: ‘wxEvtHandler’ is an inaccessible base of ‘ModInfoDialog’
  157 |     return static_cast<void (wxEvtHandler::*)(E&)>(pmf);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/wx-3.2/wx/event.h:157:12: note:    in pointer to member function conversion
```

This appears to be because the the ModInfoDialog class inherits from wxDialog, but does so privately. Changing the code to inherit publicly allows wxLauncher to compile with wxwidgets 3.2.

Though this compiles, running the code I encountered assertion errors about argument types not being correct. I tracked them down to some logging calls where the `%d` format specifier was being used for arguments with the type `size_t`. `size_t` is [always an unsigned type](https://stackoverflow.com/questions/1089176/is-size-t-always-unsigned), but the length varies based on the platform. In theory the fix here is to [use a format specifier of `%zu`](https://stackoverflow.com/questions/2125845/platform-independent-size-t-format-specifiers-in-c), which specifies an unsigned integer with the same length as `size_t`. However, the `z` length specifier was only added in wxWidgets 3.1.0, so using it in this case would not maintain compatibility. However, the actual values in these cases will be relatively small, plenty small enough to be held in a regular unsigned integer; therefore I cast them to `unsigned` and change the specifier to `%u`.